### PR TITLE
Remove unused parent variable

### DIFF
--- a/components/component.i.php
+++ b/components/component.i.php
@@ -23,7 +23,7 @@ abstract class Components_Component extends ParserBlock
 		return $this;
 	}
 
-	protected function _insertIntoTree( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node , $raw_string=null , $pre_processed=null ) {
+	protected function _insertIntoTree(Parser $parser, Tree_Branch $parent_node, $raw_string=null, $pre_processed=null) {
 		// filter
 		if ( $this->_capture === false ) $value = null; // null values are used to keep a raw tree that can be full recombined
 		elseif ( $this->_cb_process ) $value = call_user_func( $this->_cb_process , ( $pre_processed === null ? $raw_string : $pre_processed ) , $raw_string );

--- a/components/enclosedstring.i.php
+++ b/components/enclosedstring.i.php
@@ -20,7 +20,7 @@ class Components_EnclosedString extends Components_Component
 		$this->_escape_character = $escape_character;
 	}
 
-	public function parse( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node , ParserStream $stream ) {
+	public function parse(Parser $parser, Tree_Branch $parent_node, ParserStream $stream) {
 		// take stream snapshot
 		$stream->snapshot();
 
@@ -79,7 +79,7 @@ class Components_EnclosedString extends Components_Component
 		}
 
 		// insert node into tree
-		$this->_insertIntoTree( $parser , $parent , $parent_node , $delimiter . $string . $delimiter , $value );
+		$this->_insertIntoTree($parser, $parent_node, $delimiter . $string . $delimiter, $value);
 
 		return true;
 	}

--- a/components/preg.i.php
+++ b/components/preg.i.php
@@ -33,7 +33,7 @@ class Components_Preg extends Components_Component
 		return $this;
 	}
 
-	public function parse( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node , ParserStream $stream ) {
+	public function parse(Parser $parser, Tree_Branch $parent_node, ParserStream $stream) {
 		$peek = $stream->peek( $this->_max_length );
 
 		// run match
@@ -47,7 +47,7 @@ class Components_Preg extends Components_Component
 			$stream->skip( strlen( $match[ 0 ] ) );
 
 			// add node
-			$this->_insertIntoTree( $parser , $parent , $parent_node , $match[ 0 ] );
+			$this->_insertIntoTree($parser, $parent_node, $match[0]);
 
 			return true;
 		}

--- a/components/string.i.php
+++ b/components/string.i.php
@@ -27,7 +27,7 @@ class Components_String extends Components_Component
 		return $this;
 	}
 
-	public function parse( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node , ParserStream $stream ) {
+	public function parse(Parser $parser, Tree_Branch $parent_node, ParserStream $stream) {
 		// use comparison function
 		$function = ( $this->_case_sensitive ? 'strcmp' : 'strcasecmp' );
 
@@ -41,7 +41,7 @@ class Components_String extends Components_Component
 			$stream->skip( $sl );
 
 			// add node
-			$this->_insertIntoTree( $parser , $parent , $parent_node , $peek );
+			$this->_insertIntoTree($parser, $parent_node, $peek);
 
 			// success
 			return true;

--- a/components/whitespace.i.php
+++ b/components/whitespace.i.php
@@ -27,7 +27,7 @@ class Components_Whitespace extends Components_Component
 		return $this;
 	}
 
-	public function parse( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node , ParserStream $stream ) {
+	public function parse(Parser $parser, Tree_Branch $parent_node, ParserStream $stream) {
 		$raw = '';
 
 		while ( true ) {
@@ -67,13 +67,13 @@ class Components_Whitespace extends Components_Component
 		}
 
 		// add node
-		$this->_insertIntoTree( $parser , $parent , $parent_node , $raw );
+		$this->_insertIntoTree($parser, $parent_node, $raw);
 
 		return true;
 	}
 
 	// TODO: compare performance... probably faster for whitespace heavy parse strings
-	public function parseAlternative( Parser $parser , ParserBlock $parent , Tree_Node $parent_node , ParserStream $stream ) {
+	public function parseAlternative(Parser $parser, Tree_Branch $parent_node, ParserStream $stream) {
 		$raw = '';
 		$chunk_size = 8;
 
@@ -105,7 +105,7 @@ class Components_Whitespace extends Components_Component
 		}
 
 		// add node
-		$this->_insertIntoTree( $parser , $parent , $parent_node , $raw );
+		$this->_insertIntoTree($parser, $parent_node, $raw);
 
 		return true;
 	}

--- a/parser.i.php
+++ b/parser.i.php
@@ -156,7 +156,7 @@ class Parser
 			$this->_next_block = null; // in case none set by block
 
 			// error parsing section?
-			if ( !$block->parse( $this , null , $this->_tree , $stream ) ) {
+			if (!$block->parse($this, $this->_tree, $stream)) {
 				// throw error exception
 				throw $this->_throwPotentialException( new ParserException( 'Unable to match "' . $block . '".' ) );
 			}

--- a/parserblock.i.php
+++ b/parserblock.i.php
@@ -23,7 +23,7 @@ abstract class ParserBlock
      */
     protected $_capture;
 
-	abstract public function parse( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node , ParserStream $stream );
+	abstract public function parse(Parser $parser, Tree_Branch $parent_node, ParserStream $stream);
 
 	/**
 	 * @param string $name
@@ -44,5 +44,5 @@ abstract class ParserBlock
 		return 'unnamed block [' . get_class($this) . ']';
 	}
 
-	abstract protected function _insertIntoTree( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node );
+	abstract protected function _insertIntoTree(Parser $parser, Tree_Branch $parent_node);
 }

--- a/sections/delimitedset.i.php
+++ b/sections/delimitedset.i.php
@@ -56,7 +56,7 @@ class Sections_DelimitedSet extends Sections_Section
 		return $this;
 	}
 
-	public function parse( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node , ParserStream $stream ) {
+	public function parse(Parser $parser, Tree_Branch $parent_node, ParserStream $stream) {
 		// snapshot
 		$stream->snapshot();
 
@@ -74,14 +74,14 @@ class Sections_DelimitedSet extends Sections_Section
 			// get delimiter for second and subsequent entries
 			if ( $matched > 0 ) {
 				// check for delimiter
-				if ( !$block_delimiter->parse( $parser , $this , $node , $stream ) ) {
+				if (!$block_delimiter->parse($parser, $node, $stream)) {
 					// no delimiter? end of delimited set
 					break;
 				}
 			}
 
 			// get entry
-			if ( !$block_entry->parse( $parser , $this , $node , $stream ) ) {
+			if (!$block_entry->parse($parser, $node, $stream)) {
 				// no entries is an acceptable value
 				if ( $matched === 0 ) break;
 
@@ -113,7 +113,7 @@ class Sections_DelimitedSet extends Sections_Section
 		$stream->commit();
 
 		// insert nodes
-		$this->_insertIntoTree( $parser , $parent , $parent_node , $node );
+		$this->_insertIntoTree($parser, $parent_node, $node);
 
 		return true;
 	}

--- a/sections/optional.i.php
+++ b/sections/optional.i.php
@@ -15,14 +15,14 @@ class Sections_Optional extends Sections_Section
 		$this->_block = $block;
 	}
 
-	public function parse( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node , ParserStream $stream ) {
+	public function parse(Parser $parser, Tree_Branch $parent_node, ParserStream $stream) {
 		// make tree node
 		$node = new Tree_Branch();
 
 		// use component matcher
-		if ( $parser->getBlock( $this->_block )->parse( $parser , $parent , $node , $stream ) ) {
+		if ($parser->getBlock($this->_block)->parse($parser, $node, $stream)) {
 			// insert into tree
-			$this->_insertIntoTree( $parser , $parent , $parent_node , $node );
+			$this->_insertIntoTree($parser, $parent_node, $node);
 		}
 
 		return true;

--- a/sections/ordered.i.php
+++ b/sections/ordered.i.php
@@ -36,7 +36,7 @@ class Sections_Ordered extends Sections_Section
 		}
 	}
 
-	public function parse( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node , ParserStream $stream ) {
+	public function parse(Parser $parser, Tree_Branch $parent_node, ParserStream $stream) {
 		// take a stream snapshot
 		$stream->snapshot();
 
@@ -59,7 +59,7 @@ class Sections_Ordered extends Sections_Section
 					$stream->snapshot();
 
 					/** @var ParserBlock $sec */
-					if ( $parser->getBlock( $sec )->parse( $parser , $this , $node , $stream ) ) {
+					if ($parser->getBlock($sec)->parse($parser, $node, $stream)) {
 						// commit
 						$stream->commit();
 
@@ -78,7 +78,7 @@ class Sections_Ordered extends Sections_Section
 			}
 
 			// failed to match
-			if ( !$parser->getBlock( $section )->parse( $parser , $this , $node , $stream ) ) {
+			if (!$parser->getBlock($section)->parse($parser, $node, $stream)) {
 				// roll back to original snapshot
 				$stream->revert();
 
@@ -90,7 +90,7 @@ class Sections_Ordered extends Sections_Section
 		$stream->commit();
 
 		// insert tree
-		$this->_insertIntoTree( $parser , $parent , $parent_node , $node );
+		$this->_insertIntoTree($parser, $parent_node, $node);
 
 		return true;
 	}

--- a/sections/section.i.php
+++ b/sections/section.i.php
@@ -24,7 +24,7 @@ abstract class Sections_Section extends ParserBlock
         $this->_new_node = $new_node;
     }
 
-	protected function _insertIntoTree( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node , Tree_Branch $self=null ) {
+	protected function _insertIntoTree(Parser $parser, Tree_Branch $parent_node, Tree_Branch $self=null) {
 		if ( $self === null ) $self = new Tree_Branch();
 
 		// filter

--- a/sections/single.i.php
+++ b/sections/single.i.php
@@ -34,7 +34,7 @@ class Sections_Single extends Sections_Section
 		return $this;
 	}
 
-	public function parse( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node , ParserStream $stream ) {
+	public function parse(Parser $parser, Tree_Branch $parent_node, ParserStream $stream) {
 		$node = new Tree_Branch();
 
 		// look through array of sections
@@ -43,9 +43,9 @@ class Sections_Single extends Sections_Section
 			if ( is_string( $block ) ) $block = $parser->getBlock( $block );
 
 			// find first matching phrase
-			if ( $block->parse( $parser , $this , $node , $stream ) ) {
+			if ($block->parse($parser, $node, $stream)) {
 				// insert tree
-				$this->_insertIntoTree( $parser , $parent , $parent_node , $node );
+				$this->_insertIntoTree($parser, $parent_node, $node);
 
 				return true;
 			}

--- a/sections/unordered.i.php
+++ b/sections/unordered.i.php
@@ -50,7 +50,7 @@ class Sections_Unordered extends Sections_Section
 		return $this;
 	}
 
-	public function parse( Parser $parser , ParserBlock $parent , Tree_Branch $parent_node , ParserStream $stream ) {
+	public function parse(Parser $parser, Tree_Branch $parent_node, ParserStream $stream) {
 		// take snapshot
 		$stream->snapshot();
 
@@ -64,7 +64,7 @@ class Sections_Unordered extends Sections_Section
 			// look through array of sections
 			foreach ( $this->_potential_blocks as $block ) {
 				// find first matching phrase
-				if ( $parser->getBlock( $block )->parse( $parser , $this , $node , $stream ) ) {
+				if ( $parser->getBlock( $block )->parse($parser, $node, $stream)) {
 					$matched++;
 					continue;
 				}
@@ -104,7 +104,7 @@ class Sections_Unordered extends Sections_Section
 		$stream->commit();
 
 		// insert tree
-		$this->_insertIntoTree( $parser , $parent , $parent_node , $node );
+		$this->_insertIntoTree($parser, $parent_node, $node);
 
 		return true;
 	}


### PR DESCRIPTION
The `ParserBlock` parent variable passed down the parser block tree is not defined for the root element, which causes an exception in PHP 7 (it used to be that class type hints always accepted null values).

Rather than making this nullable, the current parser block implementations do not use parent information and it makes to more sense and safer for parser blocks to be context agnostic. As a result, this pull request remove the parent parser block from both the `parse` functions and the `_insertIntoTree` functions.

Closes #1 .