### PR TITLE
Workaround for operator matching in query parser

### DIFF
--- a/example/QueryParser.php
+++ b/example/QueryParser.php
@@ -25,7 +25,7 @@ class QueryParser extends \LiteLexer\Parser
 		$this->registerBlock('value', new \LiteLexer\Sections\Single('value_string', 'value_numeric', 'value_boolean', 'value_null', 'value_set'));
 
 		// add operator
-		$operators = ['<=', '>=', '>', '=>', '=<', '=', '==', '<>', '!=', 'IS', 'IS NOT', 'IN', 'NOT IN', 'LIKE', 'NOT LIKE'];
+		$operators = ['<=', '>=', '>', '=>', '=<', '=', '==', '<>', '!=', 'IS NOT', 'IS', 'IN', 'NOT IN', 'LIKE', 'NOT LIKE'];
 		$operator_blocks = array_map(function ($op) {
 			return new \LiteLexer\Components\StringLiteral($op);
 		}, $operators);

--- a/includes/Sections/Single.php
+++ b/includes/Sections/Single.php
@@ -58,7 +58,7 @@ class Single extends Section
 		// required
 		if ($this->_required) {
 			// add potential exception
-			$parser->addPotentialException($stream, new Parse(sprintf('Expection one of %s .', implode(', ', $this->_potential_blocks))));
+			$parser->addPotentialException($stream, new Parse(sprintf('Expected one of %s.', implode(', ', $this->_potential_blocks))));
 
 			return false;
 		}


### PR DESCRIPTION
A temporary workaround for the aggressive operator matching in the query parser. See #7.